### PR TITLE
fix: delete does not work

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -100,7 +100,7 @@ func (l *Loader) Delete(ctx context.Context, collectionName string, id string) e
 	defer cancel()
 
 	collection := l.database.Collection(collectionName)
-	filter := bson.M{"id": id}
+	filter := bson.M{"_id": id}
 	res, err := collection.DeleteOne(ctx, filter)
 	if err != nil {
 		return err

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -187,11 +187,9 @@ func (s *MongoSinker) applyDatabaseChanges(ctx context.Context, block bstream.Bl
 				return fmt.Errorf("updating entity %s with id %s: %w (Block %s)", change.Table, id, err, block)
 			}
 		case pbdatabase.TableChange_DELETE:
-			for range change.Fields {
-				err := s.loader.Delete(ctx, change.Table, change.Pk)
-				if err != nil {
-					return fmt.Errorf("deleting entity %s with id %s: %w (Block %s)", change.Table, id, err, block)
-				}
+			err := s.loader.Delete(ctx, change.Table, id)
+			if err != nil {
+				return fmt.Errorf("deleting entity %s with id %s: %w (Block %s)", change.Table, id, err, block)
 			}
 		}
 	}


### PR DESCRIPTION
## Fix: MongoDB document deletion not working

### Problem
Document deletion operations were failing in the MongoDB sink due to incorrect field references in the delete filter and wrong parameter usage.

### Root Cause
1. **Wrong field name**: MongoDB delete filter was using `id` instead of `_id` (MongoDB's standard primary key field)
2. **Unnecessary loop**: Delete operation was incorrectly iterating over `change.Fields`

### Solution
**`mongo/mongo.go`**:
- Fixed delete filter to use correct MongoDB primary key field:
  ```diff
  - filter := bson.M{"id": id}
  + filter := bson.M{"_id": id}  
  ```

**`sinker/sinker.go`**:
- Removed unnecessary field iteration loop for delete operations
- Fixed delete method call to use extracted ID instead of primary key object:
  ```diff
  - for range change.Fields {
  -   err := s.loader.Delete(ctx, change.Table, change.Pk)
  + err := s.loader.Delete(ctx, change.Table, id)
  ```

### Impact
- ✅ Document deletion now works correctly
- ✅ Proper MongoDB `_id` field targeting
- ✅ Consistent ID parameter usage throughout delete pipeline
- ✅ Eliminated unnecessary field iteration for delete operations

### Testing
Delete operations should now successfully remove documents from MongoDB collections using the correct primary key field reference.